### PR TITLE
IOW-699 optimize lambda memory usage

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -62,16 +62,31 @@ stepFunctions:
             Choices:
               - Variable: "$.Record.s3.object.size"
                 NumericLessThanEquals: 19200000
-                Next: captureInitialLoadSmall
+                Next: captureInitialLoadExtraSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
                   NumericGreaterThan: 19200000
                 - Variable: "$.Record.s3.object.size"
                   NumericLessThanEquals: 38400000
+                Next: captureInitialLoadSmall
+              - And:
+                - Variable: "$.Record.s3.object.size"
+                  NumericGreaterThan: 38400000
+                - Variable: "$.Record.s3.object.size"
+                  NumericLessThanEquals: 76800000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                NumericGreaterThan: 38400000
+                NumericGreaterThan: 76800000
                 Next: captureInitialLoadMedium
+          captureInitialLoadExtraSmall:
+            Type: Task
+            Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureExtraSmall
+            TimeoutSeconds: 120
+            Catch:
+              - ErrorEquals:
+                  - States.ALL
+                Next: errorHandler
+            Next: tsTypeRouterTask
           captureInitialLoadSmall:
             Type: Task
             Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,22 +61,22 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                NumericLessThanEquals: 19200000
+                NumericLessThanEquals: 25600000
                 Next: captureInitialLoadExtraSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
-                  NumericGreaterThan: 19200000
+                  NumericGreaterThan: 25600000
                 - Variable: "$.Record.s3.object.size"
-                  NumericLessThanEquals: 38400000
+                  NumericLessThanEquals: 51200000
                 Next: captureInitialLoadSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
-                  NumericGreaterThan: 38400000
+                  NumericGreaterThan: 51200000
                 - Variable: "$.Record.s3.object.size"
-                  NumericLessThanEquals: 76800000
+                  NumericLessThanEquals: 102400000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                NumericGreaterThan: 76800000
+                NumericGreaterThan: 102400000
                 Next: captureInitialLoadMedium
           captureInitialLoadExtraSmall:
             Type: Task

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,17 +61,17 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                  NumericLessThanEquals: 25600000
-                  Next: captureInitialLoadSmall
+                NumericLessThanEquals: 25600000
+                Next: captureInitialLoadSmall
               - And:
-                  - Variable: "$.Record.s3.object.size"
-                    NumericGreaterThan: 25600000
-                  - Variable: "$.Record.s3.object.size"
-                    NumericLessThanEquals: 51200000
+                - Variable: "$.Record.s3.object.size"
+                  NumericGreaterThan: 25600000
+                - Variable: "$.Record.s3.object.size"
+                  NumericLessThanEquals: 51200000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                  NumericGreaterThan: 150000000
-                  Next: captureInitialLoadMedium
+                NumericGreaterThan: 150000000
+                Next: captureInitialLoadMedium
           captureInitialLoadSmall:
             Type: Task
             Resource: arn:aws:lambda:${self:provider.region}:${self:custom.accountNumber}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,7 +61,13 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                NumericLessThanEquals: 25600000
+                NumericLessThanEquals: 12800000
+                Next: captureInitialLoadExtraSmall
+              - And:
+                  - Variable: "$.Record.s3.object.size"
+                    NumericGreaterThan: 12800000
+                  - Variable: "$.Record.s3.object.size"
+                    NumericLessThanEquals: 25600000
                 Next: captureInitialLoadSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
@@ -72,6 +78,15 @@ stepFunctions:
               - Variable: "$.Record.s3.object.size"
                 NumericGreaterThan: 150000000
                 Next: captureInitialLoadMedium
+          captureInitialLoadExtraSmall:
+            Type: Task
+            Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureExtraSmall
+            TimeoutSeconds: 120
+            Catch:
+              - ErrorEquals:
+                  - States.ALL
+                Next: errorHandler
+            Next: tsTypeRouterTask
           captureInitialLoadSmall:
             Type: Task
             Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,13 +61,7 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                NumericLessThanEquals: 12800000
-                Next: captureInitialLoadExtraSmall
-              - And:
-                  - Variable: "$.Record.s3.object.size"
-                    NumericGreaterThan: 12800000
-                  - Variable: "$.Record.s3.object.size"
-                    NumericLessThanEquals: 25600000
+                NumericLessThanEquals: 25600000
                 Next: captureInitialLoadSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
@@ -78,15 +72,6 @@ stepFunctions:
               - Variable: "$.Record.s3.object.size"
                 NumericGreaterThan: 51200000
                 Next: captureInitialLoadMedium
-          captureInitialLoadExtraSmall:
-            Type: Task
-            Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureExtraSmall
-            TimeoutSeconds: 120
-            Catch:
-              - ErrorEquals:
-                  - States.ALL
-                Next: errorHandler
-            Next: tsTypeRouterTask
           captureInitialLoadSmall:
             Type: Task
             Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,7 +76,7 @@ stepFunctions:
                   NumericLessThanEquals: 51200000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                NumericGreaterThan: 150000000
+                NumericGreaterThan: 51200000
                 Next: captureInitialLoadMedium
           captureInitialLoadExtraSmall:
             Type: Task

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,7 +74,7 @@ stepFunctions:
                 Next: captureInitialLoadMedium
           captureInitialLoadSmall:
             Type: Task
-            Resource: arn:aws:lambda:${self:provider.region}:${self:custom.accountNumber}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall
+            Resource: arn:aws:lambda:${self:provider.region}:#{AWS::AccountId}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall
             TimeoutSeconds: 120
             Catch:
               - ErrorEquals:

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,16 +61,16 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                NumericLessThanEquals: 25600000
+                NumericLessThanEquals: 19200000
                 Next: captureInitialLoadSmall
               - And:
                 - Variable: "$.Record.s3.object.size"
-                  NumericGreaterThan: 25600000
+                  NumericGreaterThan: 19200000
                 - Variable: "$.Record.s3.object.size"
-                  NumericLessThanEquals: 51200000
+                  NumericLessThanEquals: 38400000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                NumericGreaterThan: 51200000
+                NumericGreaterThan: 38400000
                 Next: captureInitialLoadMedium
           captureInitialLoadSmall:
             Type: Task

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,11 +56,26 @@ stepFunctions:
             Type: Choice
             Choices:
               - Variable: "$.Record.s3.object.size"
-                NumericLessThanEquals: 51200000
+                  NumericLessThanEquals: 25600000
+                  Next: captureInitialLoadSmall
+              - And:
+                  - Variable: "$.Record.s3.object.size"
+                    NumericGreaterThan: 25600000
+                  - Variable: "$.Record.s3.object.size"
+                    NumericLessThanEquals: 51200000
                 Next: captureInitialLoad
               - Variable: "$.Record.s3.object.size"
-                NumericGreaterThan: 51200000
-                Next: captureInitialLoadMedium
+                  NumericGreaterThan: 150000000
+                  Next: captureInitialLoadMedium
+          captureInitialLoadSmall:
+            Type: Task
+            Resource: arn:aws:lambda:${self:provider.region}:${self:custom.accountNumber}:function:aqts-capture-raw-load-${self:provider.stage}-iowCaptureSmall
+            TimeoutSeconds: 120
+            Catch:
+              - ErrorEquals:
+                  - States.ALL
+                Next: errorHandler
+            Next: tsTypeRouterTask
           captureInitialLoad:
             Type: Task
             Resource: arn:aws:lambda:${self:provider.region}:${self:custom.accountNumber}:function:aqts-capture-raw-load-${self:provider.stage}-iowCapture


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Optimize raw load further, by adding a third "small" category of lambda function

Description
-----------
The current implementation has 512 mb of memory for the smaller implementation of the lambda, but many invocations use less than 256 mb.  Add a 'small' lambda function to run at 256 mb.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
