### PR TITLE
Bump the state field visit transform state timeout a bit higher than …

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -256,7 +256,7 @@ stepFunctions:
               partitionNumber.$: $.partitionNumber
               type.$: $.tsTypeRouterResult.type
             ResultPath: $.fieldVisitTransformResult
-            TimeoutSeconds: 100
+            TimeoutSeconds: 280
             Catch:
               - ErrorEquals:
                   - States.ALL


### PR DESCRIPTION
…the current lambda timeout

Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
https://internal.cida.usgs.gov/jira/browse/IOW-843

Description
-----------
* Make the field visit transform state timeout 10 seconds longer than the lambda's timeout: https://github.com/usgs/aqts-capture-field-visit-transform/blob/master/serverless.yml#L14

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
